### PR TITLE
Add Locale+UserPreferredTimeFormat.swift

### DIFF
--- a/ADUtils.xcodeproj/project.pbxproj
+++ b/ADUtils.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		49F0F23621637ADD00FC8AA4 /* NibTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49F0F23521637ADD00FC8AA4 /* NibTableViewCell.xib */; };
 		49F0F23821639D6900FC8AA4 /* NibTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49F0F23721639D6900FC8AA4 /* NibTableHeaderView.xib */; };
 		4AE8A6D323F563F300ABE095 /* DebouncedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE8A6D223F563F300ABE095 /* DebouncedTests.swift */; };
+		57397F7D24CAD105001C6F2E /* LocaleUserPreferredTimeFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57397F7C24CAD105001C6F2E /* LocaleUserPreferredTimeFormatTests.swift */; };
 		57C59D681BB1478A003798DF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57C59D671BB1478A003798DF /* Images.xcassets */; };
 		57C59D6A1BB1486B003798DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 57C59D691BB1486B003798DF /* LaunchScreen.storyboard */; };
 		57E1CD281C884F1C00A7DFFB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E1CD271C884F1C00A7DFFB /* ViewController.swift */; };
@@ -104,6 +105,7 @@
 		49F0F23721639D6900FC8AA4 /* NibTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = NibTableHeaderView.xib; path = Defaults/NibTableHeaderView.xib; sourceTree = "<group>"; };
 		4AE8A6D223F563F300ABE095 /* DebouncedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncedTests.swift; sourceTree = "<group>"; };
 		4C8B60A08D066BFD9DDA1251 /* Pods-ADUtilsApp.distribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ADUtilsApp.distribution.xcconfig"; path = "Pods/Target Support Files/Pods-ADUtilsApp/Pods-ADUtilsApp.distribution.xcconfig"; sourceTree = "<group>"; };
+		57397F7C24CAD105001C6F2E /* LocaleUserPreferredTimeFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleUserPreferredTimeFormatTests.swift; sourceTree = "<group>"; };
 		57C59D671BB1478A003798DF /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		57C59D691BB1486B003798DF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		57E1CD271C884F1C00A7DFFB /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				EC626C6C1FA07281001C332C /* HelveticaNeue.plist */,
 				49D1F130216C968E009F87AB /* ADUtilsTests-Bridging-Header.h */,
 				F2F326C02448431300BB5700 /* NSDirectionalEdgeInsetsTests.swift */,
+				57397F7C24CAD105001C6F2E /* LocaleUserPreferredTimeFormatTests.swift */,
 			);
 			path = ADUtilsTests;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				49F0F20F21621EB300FC8AA4 /* DeselectableViewTests.swift in Sources */,
 				EC7953421ECB5C7B00404857 /* ViewLayoutTest.swift in Sources */,
 				EC368BC41EDF13DA00661556 /* OptionalUnwrapTest.swift in Sources */,
+				57397F7D24CAD105001C6F2E /* LocaleUserPreferredTimeFormatTests.swift in Sources */,
 				E7F92DA81FFBD9B200A85AB4 /* GeometryUtilitiesTest.swift in Sources */,
 				496EB3BD246003EA0011B4AD /* NavigationControllerPopCompletionTests.swift in Sources */,
 				49D1F134216CCEF4009F87AB /* ADViewLayoutGuideTestsObjc.m in Sources */,

--- a/ADUtilsTests/LocaleUserPreferredTimeFormatTests.swift
+++ b/ADUtilsTests/LocaleUserPreferredTimeFormatTests.swift
@@ -1,0 +1,41 @@
+//
+//  LocaleUserPreferredTimeFormatTests.swift
+//  ADUtilsTests
+//
+//  Created by Edouard Siegel on 24/07/2020.
+//
+
+import Foundation
+import Quick
+import Nimble
+import ADUtils
+
+class LocaleUserPreferredTimeFormatTests: QuickSpec {
+
+    override func spec() {
+        describe("When using an US region locale") {
+            it("should return a 12 hours format for en_US locale") {
+                let locale = Locale(identifier: "en_US")
+                expect(locale.ad_userPrefers12HoursFormat).to(beTrue())
+            }
+
+            it("should return a 12 hours format for fr_US locale") {
+                let locale = Locale(identifier: "fr_US")
+                expect(locale.ad_userPrefers12HoursFormat).to(beTrue())
+            }
+        }
+
+        describe("When using an FR region locale") {
+            it("should return a 24 hours format for en_FR locale") {
+                let locale = Locale(identifier: "en_FR")
+                expect(locale.ad_userPrefers12HoursFormat).to(beFalse())
+            }
+
+            it("should return a 24 hours format for fr_FR locale") {
+                let locale = Locale(identifier: "fr_FR")
+                expect(locale.ad_userPrefers12HoursFormat).to(beFalse())
+            }
+        }
+    }
+
+}

--- a/Modules/ADUtils/Locale+UserPreferredTimeFormat.swift
+++ b/Modules/ADUtils/Locale+UserPreferredTimeFormat.swift
@@ -1,0 +1,30 @@
+//
+//  Locale+UserPreferredTimeFormat.swift
+//  ADUtils
+//
+//  Created by Edouard Siegel on 24/07/2020.
+//
+
+import Foundation
+
+public extension Locale {
+
+    /*
+     courtesy of https://stackoverflow.com/a/11660380/900937
+
+     This uses a special date template string called "j". According to the ICU Spec, "j":
+     requests the preferred hour format for the locale (h, H, K, or k), as determined by whether h, H, K, or k is used
+     in the standard short time format for the locale. In the implementation of such an API, 'j' must be replaced by h,
+     H, K, or k before beginning a match against availableFormats data. Note that use of 'j' in a skeleton passed to an
+     API is the only way to have a skeleton request a locale's preferred time cycle type (12-hour or 24-hour).
+
+     That last sentence is important. It "is the only way to have a skeleton request a locale's preferred time cycle
+     type". Since NSDateFormatter and NSCalendar are built on the ICU library, the same holds true here.
+     */
+    var ad_userPrefers12HoursFormat: Bool {
+        guard let formatString = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: self) else {
+            return false
+        }
+        return formatString.contains("a")
+    }
+}


### PR DESCRIPTION
Add Locale extension variable for easy access to user time format preference. Most notably, knowing whether the user uses a 12 or 24 hours format.

Simply use 
`Locale.current.userPrefers12HoursFormat`
which gives a Bool back