### PR TITLE
Add fetch depth parameter to the CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Not having the fetch-depth parameter can cause issues with Danger