### PR TITLE
Add Privacy Manifest

### DIFF
--- a/ADUtils.podspec
+++ b/ADUtils.podspec
@@ -15,17 +15,23 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'Swift' do |subspec|
     # Subspec compliant with App extensions
+    subspec.dependency 'ADUtils/Privacy'
     subspec.source_files = 'Modules/ADUtils/*.{h,m,swift}'
   end
 
   spec.subspec 'Security' do |subspec|
+    subspec.dependency 'ADUtils/Privacy'
     subspec.source_files = 'Modules/ADUtils_security/*.{h,m,swift}'
     subspec.framework    = 'CryptoKit'
   end
 
   spec.subspec 'objc' do |subspec|
     subspec.dependency 'ADUtils/Swift'
-	subspec.source_files = 'Modules/ADUtils_objc/*.{h,m,swift}'
+    subspec.source_files = 'Modules/ADUtils_objc/*.{h,m,swift}'
+  end
+
+  spec.subspec 'Privacy' do |subspec|
+    subspec.resource_bundles = {'ADUtilsPrivacy' => ['Modules/PrivacyInfo.xcprivacy']}
   end
 
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `PrivacyInfo.xcprivacy` to comply with Apple new privacy requirements
+
 ## [12.1.1] - 2024-02-22
 
 ### Fixed

--- a/Modules/PrivacyInfo.xcprivacy
+++ b/Modules/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         .target(
             name: "ADUtils",
             dependencies: [],
-            path: "Modules"
+            path: "Modules",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         )
     ]
 )


### PR DESCRIPTION
D’après https://github.com/Wooder/ios_17_required_reason_api_scanner

Found potentially required reason API usage 'UserDefaults' in '/Users/edouard.siegel1/Sources/ADUtils//Modules/ADUtils/PropertyListArchiver.swift'
Line numbers: 20 24 28 
Found potentially required reason API usage 'UserDefaults' in '/Users/edouard.siegel1/Sources/ADUtils//Modules/ADUtils_security/PostInstallationKeychainCleaner.swift'
Line numbers: 42 51 62 
Found potentially required reason API usage 'UserDefaults' in '/Users/edouard.siegel1/Sources/ADUtils//Modules/ADUtils_security/UserDefaults+StorageArchiver.swift'
Line numbers: 2 10 

Du coup, besoin du Privacy dans `Security` et dans `Swift`.